### PR TITLE
Github 页面改版，更新 `regex` 规则

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -10,10 +10,10 @@ def getdata(name):
     gitpage = requests.get("https://github.com/" + name)
     data = gitpage.text
     datadatereg = re.compile(r'data-date="(.*?)" data-level')
-    datacountreg = re.compile(r'data-count="(.*?)" data-date')
+    datacountreg = re.compile(r'rx="2" ry="2">(.*?) contribution')
     datadate = datadatereg.findall(data)
     datacount = datacountreg.findall(data)
-    datacount = list(map(int, datacount))
+    datacount = list(map(int, [0 if i == "No" else i for i in datacount]))
     contributions = sum(datacount)
     datalist = []
     for index, item in enumerate(datadate):

--- a/api/index.py
+++ b/api/index.py
@@ -10,7 +10,7 @@ def getdata(name):
     gitpage = requests.get("https://github.com/" + name)
     data = gitpage.text
     datadatereg = re.compile(r'data-date="(.*?)" data-level')
-    datacountreg = re.compile(r'rx="2" ry="2">(.*?) contribution')
+    datacountreg = re.compile(r'<span class="sr-only">(.*?) contribution')
     datadate = datadatereg.findall(data)
     datacount = datacountreg.findall(data)
     datacount = list(map(int, [0 if i == "No" else i for i in datacount]))


### PR DESCRIPTION
原版：
![49a77f9684aa1bbc2271c23e2ee94e83](https://user-images.githubusercontent.com/62864752/210919291-1dbf35f0-b9e5-4281-86a0-bdcba4f650b3.png)
改版后：
![da44dba543bbe9aca7104e850671e0d9](https://user-images.githubusercontent.com/62864752/210919297-2e73954c-e314-4611-93a1-dcfe1159b7e4.png)

更新了正则使其可以继续运行

```py
    datacountreg = re.compile(r'<span class="sr-only">(.*?) contribution')
```

将 `No` 替换成 `0`

```py
    datacount = list(map(int, [0 if i == "No" else i for i in datacount]))
```

> 2023.7.16 再次跟进正则