### PR TITLE
合并2023-11的正则表达式更改，修复2024-02 因Vercel在不符合key-value规范的url后加等号导致的api失效

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,7 +1,6 @@
-# -*- coding: UTF-8 -*-
 import requests
 import re
-from http.server import BaseHTTPRequestHandler
+from http.server import BaseHTTPRequestHandler,HTTPServer
 import json
 
 def list_split(items, n):
@@ -9,8 +8,8 @@ def list_split(items, n):
 def getdata(name):
     gitpage = requests.get("https://github.com/" + name)
     data = gitpage.text
-    datadatereg = re.compile(r'data-date="(.*?)" data-level')
-    datacountreg = re.compile(r'<span class="sr-only">(.*?) contribution')
+    datadatereg = re.compile(r'data-date="(.*?)" id="contribution-day-component')
+    datacountreg = re.compile(r'position-absolute">(.*?) contribution')
     datadate = datadatereg.findall(data)
     datacount = datacountreg.findall(data)
     datacount = list(map(int, [0 if i == "No" else i for i in datacount]))
@@ -33,7 +32,7 @@ def getdata(name):
 class handler(BaseHTTPRequestHandler):
     def do_GET(self):
         path = self.path
-        user = path.split('?')[1]
+        user = path.split('?')[1][:-1]
         data = getdata(user)
         self.send_response(200)
         self.send_header('Access-Control-Allow-Origin', '*')

--- a/api/index.py
+++ b/api/index.py
@@ -1,6 +1,6 @@
 import requests
 import re
-from http.server import BaseHTTPRequestHandler,HTTPServer
+from http.server import BaseHTTPRequestHandler
 import json
 
 def list_split(items, n):


### PR DESCRIPTION
详细请见：https://github.com/Zfour/python_github_calendar_api/issues/20

因为本pr是在不改变原请求格式的情况强制截去vercel自动添加的等号，而且vercel官方后续还有改回去的可能性，所以后来创建了使用 `https://apiurl/api?user={username}` 格式符合kv规范的fork

https://github.com/LYXOfficial/gitcalendarapi/
或https://github.com/Barry-Flynn/python_github_calendar_api/

前端修改请见issue